### PR TITLE
continueUserActivity をフックするよう修正

### DIFF
--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -309,7 +309,6 @@ NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
     return processedResponses;
 }
 
-
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
@@ -320,10 +319,21 @@ NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
     
     return NO;
 }
+
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation {
     return [self application:application openURL:url options:@{}];
 }
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler {
+    if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:userActivity.webpageURL]) {
+        _currentAuthorizationFlow = nil;
+        return YES;
+    }
+    
+    return YES;
+}
+
 @end


### PR DESCRIPTION
## 対応内容

内部的には `AsWebAuthenticationsession` を使ってログインのコールバックを取得しようとしているが反応しない。

Universal links の場合にコールバックが呼ばれるのは 以下の関数だが、こちらをフックしていなかったのでフックすることで対応しました。

`func application(_ application: NSApplication,
                     continue userActivity: NSUserActivity,
                     restorationHandler: @escaping ([NSUserActivityRestoring]) -> Void) -> Bool`

## 参考

https://stackoverflow.com/questions/61748589/does-aswebauthenticationsession-support-universal-links

https://developer.apple.com/documentation/xcode/allowing_apps_and_websites_to_link_to_your_content/supporting_universal_links_in_your_app